### PR TITLE
Use Rails executor when launching new Thread

### DIFF
--- a/lib/sidekiq/shutdown_cleanup/middleware.rb
+++ b/lib/sidekiq/shutdown_cleanup/middleware.rb
@@ -10,7 +10,11 @@ module Sidekiq
       end
 
       def safe_execute(worker, args)
-        thread = Thread.new { yield }
+        thread = Thread.new do
+          Rails.application.executor.wrap do
+            yield
+          end
+        end
         # While the thread has not terminated
         while thread.status
           if @@shutting_down


### PR DESCRIPTION
https://guides.rubyonrails.org/threading_and_code_execution.html#executor

Hopefully this will ensure that all application connections are re-established.